### PR TITLE
use the version file for chrome-driver for tag instead of version file contained in the repo

### DIFF
--- a/.concourse/build-and-push-selenium.yml
+++ b/.concourse/build-and-push-selenium.yml
@@ -70,17 +70,17 @@ jobs:
       - put: selenium-base
         params:
           build: docker-qa-images/selenium/base
-          tag_file: docker-qa-images/selenium/VERSION
+          tag_file: chromedriver-latest/version
           tag_as_latest: true
       - put: selenium-chrome
         params:
           build: docker-qa-images/selenium/chrome
-          tag_file: docker-qa-images/selenium/VERSION
+          tag_file: chromedriver-latest/version
           tag_as_latest: true
       - put: selenium-chrome-debug
         params:
           build: docker-qa-images/selenium/chrome-debug
-          tag_file: docker-qa-images/selenium/VERSION
+          tag_file: chromedriver-latest/version
           tag_as_latest: true
     on_success:
       put: notify-slack


### PR DESCRIPTION
This will use the version file that is created that is used within the concourse pipeline to tag the docker images instead of the VERSION file that is in the repository.